### PR TITLE
fix gatsby-theme-apollo readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin will set up a Gatsby project for use with [Apollo](https://www.apollographql.com/docs/react/), in the most minimal way imaginable.
 
-**Note:** This plugin accepts [only a few](#options) of the [options accepted by Apollo Boost](https://www.apollographql.com/docs/react/essentials/get-started/#apollo-boost). If you need to use a more advanced Apollo Client configuration, use [gatsby-theme-apollo](https://github.com/apollographql/gatsby-theme-apollo) instead.
+**Note:** This plugin accepts [only a few](#options) of the [options accepted by Apollo Boost](https://www.apollographql.com/docs/react/essentials/get-started/#apollo-boost). If you need to use a more advanced Apollo Client configuration, use [gatsby-theme-apollo](https://github.com/apollographql/gatsby-theme-apollo/tree/master/packages/gatsby-theme-apollo) instead.
 
 - [Installation](#installation)
 - [Usage](#usage)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin will set up a Gatsby project for use with [Apollo](https://www.apollographql.com/docs/react/), in the most minimal way imaginable.
 
-**Note:** This plugin accepts [only a few](#options) of the [options accepted by Apollo Boost](https://www.apollographql.com/docs/react/essentials/get-started/#apollo-boost). If you need to use a more advanced Apollo Client configuration, use [gatsby-theme-apollo](https://github.com/apollographql/gatsby-theme-apollo/packages/gatsby-theme-apollo) instead.
+**Note:** This plugin accepts [only a few](#options) of the [options accepted by Apollo Boost](https://www.apollographql.com/docs/react/essentials/get-started/#apollo-boost). If you need to use a more advanced Apollo Client configuration, use [gatsby-theme-apollo](https://github.com/apollographql/gatsby-theme-apollo) instead.
 
 - [Installation](#installation)
 - [Usage](#usage)


### PR DESCRIPTION
The old link was broken.
However, I'm not sure which link you wanted it to go to. 
I took a guess and sent it here: https://github.com/apollographql/gatsby-theme-apollo

Thanks for your plugin!! 